### PR TITLE
Add helpful args to "par" command

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -45,7 +45,7 @@ set tm=2000
 noremap ,, ,
 
 " Use par for prettier line formatting
-set formatprg=par\ -w72
+set formatprg="PARINIT='rTbgqR B=.,?_A_a Q=_s>|' par\ -w72"
 
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""


### PR DESCRIPTION
This adds some handy arguments to `par`. I found that par would occasionally do some weird stuff in cases like:

```
Some thing ending with period.
Other thing ending with that same period.
```

formatting them (very short length for effect) would yield something like:

```
Some thing ending  .
with period. Other .
thing ending with  .
that same period   .
```

In other cases lines that happened to start with the same phrase over and over again would have lines joined by that phrase. The options here tell par that "body" characters are `[.,?A-Za-z]`, "quote" characters are `[ >|]+` (like in an email), and that it should expand tabs to spaces (and some other really fiddly stuff). I've gotten much better behavior from these settings.
